### PR TITLE
Fix OpenCV dependency definition

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,14 +21,14 @@
   <depend>cv_bridge</depend>
 
   <exec_depend>gazebo_ros</exec_depend>
-  <exec_depend>libopencv3</exec_depend>
+  <exec_depend>libopencv-dev</exec_depend>
 
   <test_depend>rosunit</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>cmake_modules</test_depend>
   <test_depend>tinyxml</test_depend>
   
-  <build_depend>libopencv3</build_depend>
+  <build_depend>libopencv-dev</build_depend>
   <build_depend>roslint</build_depend>
   <build_depend>gazebo_dev</build_depend>
   <build_depend>sonar_msgs</build_depend>


### PR DESCRIPTION
## Description

- Fix the opencv dep name from `libopencv3` to `libopencv-dev`. It was not breaking the CI tests (probably because other deps might already have opencv as a dependency), but they log the error `forward_looking_sonar_gazebo: Cannot locate rosdep definition for [libopencv3]`